### PR TITLE
メッセージ履歴の永続化機能を追加

### DIFF
--- a/src/lib/server/api.ts
+++ b/src/lib/server/api.ts
@@ -111,6 +111,15 @@ export const apiRouter = new Hono()
     .get('/session', async (c) => {
         const sessions = await sessionManager.listSessions();
         return c.json({ sessionIds: sessions });
+    })
+    .get('/session/:sessionId/messages', async (c) => {
+        const sessionId = c.req.param('sessionId');
+        const session = sessionManager.getSessionById(sessionId);
+        if (!session) {
+            return c.json({ error: 'Session not found' }, 404);
+        }
+        const messages = session.getAllMessages();
+        return c.json({ messages });
     });
 
 export type ApiRouter = typeof apiRouter;

--- a/src/lib/server/domain.ts
+++ b/src/lib/server/domain.ts
@@ -112,6 +112,7 @@ export interface SessionHandler {
     sessionId(): string;
     pushMessage(massage: string): Promise<void | Error>;
     listenEvent(listener: (event: ServerEvent, unsubnscribe: () => void) => void): { unsubscribe(): void };
+    getAllMessages(): SessionMessage[];
     answerApproval(approvalId: string, data: CodingApproval): Promise<void>;
     close(): Promise<void>;
 }


### PR DESCRIPTION
## Summary
- チャットセッションでのメッセージ履歴の永続化機能を実装
- ページリロード時にメッセージ履歴を復元する機能を追加  
- 承認メッセージの状態管理を改善

## Test plan
- [ ] 新しいチャットセッションを作成してメッセージを送信
- [ ] ページをリロードしてメッセージ履歴が復元されることを確認
- [ ] 承認メッセージの状態が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)